### PR TITLE
Add HTTP server support for cloud platform deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target/
+.git/
+.gitignore
+*.md
+deny.toml
+rustfmt.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +360,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -426,6 +478,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "chrono"
@@ -549,6 +612,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1070,6 +1142,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1232,6 +1305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1330,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1618,6 +1698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1754,12 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1908,6 +2000,7 @@ name = "optopsy-mcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "blackscholes",
  "cargo-husky",
  "chrono",
@@ -2781,6 +2874,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,6 +2921,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_distr"
@@ -3025,18 +3135,27 @@ checksum = "8a0ce46f9101dc911f07e1468084c057839d15b08040d110820c5513312ef56a"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand 0.10.0",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3365,6 +3484,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_stacker"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3394,7 +3524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3405,7 +3535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3761,6 +3891,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4090,6 +4233,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ default = []
 postgres = ["sqlx"]
 
 [dependencies]
-rmcp = { version = "0.17", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "0.17", features = ["server", "transport-io", "transport-streamable-http-server", "macros"] }
+axum = "0.8"
 polars = { version = "0.53", features = ["lazy", "parquet", "dtype-date", "dtype-datetime", "dtype-struct", "round_series", "is_in", "cum_agg", "rolling_window", "abs", "cross_join"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Stage 1: Build
+FROM rust:1.84-bookworm AS builder
+
+WORKDIR /app
+
+# Copy manifests first for dependency caching
+COPY Cargo.toml Cargo.lock ./
+
+# Create a dummy src to pre-build dependencies
+RUN mkdir src && echo "fn main() {}" > src/main.rs
+RUN cargo build --release 2>/dev/null || true
+RUN rm -rf src
+
+# Copy real source and build
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/optopsy-mcp /usr/local/bin/optopsy-mcp
+
+ENV RUST_LOG=info
+
+EXPOSE 8080
+
+CMD ["optopsy-mcp"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use rmcp::ServiceExt;
+use std::sync::Arc;
 use tracing_subscriber::{self, EnvFilter};
 
 mod data;
@@ -16,12 +17,41 @@ async fn main() -> Result<()> {
         .with_writer(std::io::stderr)
         .init();
 
-    tracing::info!("Starting optopsy-mcp MCP server");
+    let cache = Arc::new(data::cache::CachedStore::from_env()?);
 
-    let cache = data::cache::CachedStore::from_env()?;
-    let server = server::OptopsyServer::new(cache);
-    let service = server.serve(rmcp::transport::stdio()).await?;
-    service.waiting().await?;
+    if let Ok(port) = std::env::var("PORT") {
+        // HTTP mode — used by Railway and other cloud platforms
+        use rmcp::transport::streamable_http_server::{
+            session::local::LocalSessionManager, StreamableHttpService,
+        };
+
+        let service = StreamableHttpService::new(
+            move || Ok(server::OptopsyServer::new(cache.clone())),
+            LocalSessionManager::default().into(),
+            Default::default(),
+        );
+
+        let app = axum::Router::new()
+            .nest_service("/mcp", service)
+            .route("/health", axum::routing::get(|| async { "ok" }));
+
+        let addr = format!("0.0.0.0:{port}");
+        tracing::info!("Starting optopsy-mcp HTTP server on {addr}");
+
+        let listener = tokio::net::TcpListener::bind(&addr).await?;
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = tokio::signal::ctrl_c().await;
+            })
+            .await?;
+    } else {
+        // stdio mode — used for local development with Claude Desktop
+        tracing::info!("Starting optopsy-mcp MCP server (stdio)");
+
+        let server = server::OptopsyServer::new(cache);
+        let service = server.serve(rmcp::transport::stdio()).await?;
+        service.waiting().await?;
+    }
 
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,10 +24,10 @@ pub struct OptopsyServer {
 }
 
 impl OptopsyServer {
-    pub fn new(cache: CachedStore) -> Self {
+    pub fn new(cache: Arc<CachedStore>) -> Self {
         Self {
             data: Arc::new(RwLock::new(None)),
-            cache: Arc::new(cache),
+            cache,
             tool_router: Self::tool_router(),
         }
     }


### PR DESCRIPTION
## Summary
This PR adds HTTP server support to optopsy-mcp, enabling deployment on cloud platforms like Railway while maintaining backward compatibility with stdio mode for local development.

## Key Changes
- **Dual transport mode**: The server now supports both HTTP and stdio transports
  - HTTP mode is activated when the `PORT` environment variable is set
  - Stdio mode is used for local development (e.g., with Claude Desktop)
- **HTTP server implementation**: Uses Axum web framework with a `/mcp` endpoint for MCP protocol handling and a `/health` endpoint for health checks
- **Arc-wrapped cache**: The `CachedStore` is now wrapped in `Arc` to allow safe sharing across multiple HTTP request handlers
- **Docker support**: Added multi-stage Dockerfile for containerized deployment with optimized layer caching
- **Railway configuration**: Added `railway.toml` with health check and restart policies for Railway platform deployment
- **Dependencies**: Added `axum` framework and enabled `transport-streamable-http-server` feature in rmcp

## Implementation Details
- The server gracefully handles shutdown via Ctrl+C signal
- HTTP server binds to `0.0.0.0:{PORT}` to support cloud platform port binding
- The `OptopsyServer::new()` method now accepts `Arc<CachedStore>` instead of creating its own Arc wrapper, simplifying the initialization logic
- Dockerfile uses a two-stage build to optimize image size and build time

https://claude.ai/code/session_01WEusFaLS5zyUHxWNk72CV7