### PR TITLE
Consolidate clippy cast lint allows into Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ module_name_repetitions = "allow"
 must_use_candidate = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
+# Controlled numeric casts throughout (day counts, indices, etc.)
+cast_possible_truncation = "allow"
+cast_sign_loss = "allow"
+cast_possible_wrap = "allow"
+cast_precision_loss = "allow"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/engine/event_sim.rs
+++ b/src/engine/event_sim.rs
@@ -79,7 +79,6 @@ fn extract_date_from_column(col: &Column, idx: usize) -> Result<NaiveDate> {
                         }
                         TimeUnit::Nanoseconds => {
                             let secs = v / 1_000_000_000;
-                            #[allow(clippy::cast_sign_loss)]
                             let nsecs = (v % 1_000_000_000) as u32;
                             chrono::DateTime::from_timestamp(secs, nsecs).map(|dt| dt.naive_utc())
                         }
@@ -342,7 +341,6 @@ pub fn run_event_loop(
 
         // Phase 2: Enter new positions
         let open_count = positions.len();
-        #[allow(clippy::cast_sign_loss)]
         if open_count < params.max_positions as usize {
             if let Some(day_candidates) = candidates.get(&today) {
                 // Filter out candidates with expirations we already hold

--- a/src/engine/exits.rs
+++ b/src/engine/exits.rs
@@ -55,7 +55,6 @@ mod tests {
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap();
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let exit_dt = NaiveDate::from_ymd_opt(2024, 1, 1 + days_held as u32)
             .unwrap()
             .and_hms_opt(0, 0, 0)

--- a/src/engine/metrics.rs
+++ b/src/engine/metrics.rs
@@ -42,7 +42,7 @@ struct TradeMetrics {
 }
 
 /// Calculate performance metrics from equity curve and trade log
-#[allow(clippy::unnecessary_wraps, clippy::cast_precision_loss)]
+#[allow(clippy::unnecessary_wraps)]
 pub fn calculate_metrics(
     equity_curve: &[EquityPoint],
     trade_log: &[TradeRecord],
@@ -84,7 +84,6 @@ pub fn calculate_metrics(
 
 /// Compute equity-curve-derived metrics (Sharpe, Sortino, max DD, `VaR`, total return, CAGR, Calmar).
 /// Assumes `equity_curve.len() >= 2`.
-#[allow(clippy::cast_precision_loss)]
 fn compute_equity_metrics(
     equity_curve: &[EquityPoint],
     initial_capital: f64,
@@ -160,7 +159,6 @@ fn compute_equity_metrics(
     )
 }
 
-#[allow(clippy::cast_precision_loss)]
 fn compute_trade_metrics(trade_log: &[TradeRecord]) -> TradeMetrics {
     if trade_log.is_empty() {
         return TradeMetrics {
@@ -244,7 +242,6 @@ fn compute_trade_metrics(trade_log: &[TradeRecord]) -> TradeMetrics {
     }
 }
 
-#[allow(clippy::cast_precision_loss)]
 fn std_dev(data: &[f64]) -> f64 {
     if data.len() < 2 {
         return 0.0;
@@ -254,7 +251,6 @@ fn std_dev(data: &[f64]) -> f64 {
     variance.sqrt()
 }
 
-#[allow(clippy::cast_precision_loss)]
 fn downside_deviation(returns: &[f64]) -> f64 {
     if returns.len() < 2 {
         return 0.0;
@@ -314,11 +310,7 @@ mod tests {
                     .unwrap()
                     .and_hms_opt(0, 0, 0)
                     .unwrap()
-                    + chrono::Duration::days({
-                        #[allow(clippy::cast_possible_wrap)]
-                        let days = i as i64;
-                        days
-                    }),
+                    + chrono::Duration::days(i as i64),
                 equity: eq,
             })
             .collect()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,5 @@
 // float_cmp: only in tests where assert_eq! on f64 is intentional.
 #![cfg_attr(test, allow(clippy::float_cmp))]
-// Cast lints: controlled numeric casts throughout (day counts, indices, etc.).
-#![allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    clippy::cast_possible_wrap,
-    clippy::cast_precision_loss
-)]
 
 pub mod data;
 pub mod engine;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,5 @@
 // float_cmp: only in tests where assert_eq! on f64 is intentional.
 #![cfg_attr(test, allow(clippy::float_cmp))]
-// Cast lints: controlled numeric casts throughout (day counts, indices, etc.).
-#![allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    clippy::cast_possible_wrap,
-    clippy::cast_precision_loss
-)]
 
 use anyhow::Result;
 use rmcp::ServiceExt;

--- a/src/tools/ai_format.rs
+++ b/src/tools/ai_format.rs
@@ -61,7 +61,6 @@ fn sample_equity_curve(curve: &[EquityPoint], max_points: usize) -> Vec<EquityPo
     let step = (curve.len() - 1) as f64 / (max_points - 1) as f64;
     (0..max_points)
         .map(|i| {
-            #[allow(clippy::cast_precision_loss)]
             let idx = (i as f64 * step).round() as usize;
             curve[idx.min(curve.len() - 1)].clone()
         })
@@ -678,7 +677,6 @@ mod tests {
     fn sample_equity_curve_downsamples() {
         let curve: Vec<EquityPoint> = (0..100)
             .map(|i| {
-                #[allow(clippy::cast_precision_loss)]
                 let eq = 100.0 + i as f64;
                 make_equity_point(i, eq)
             })
@@ -918,7 +916,7 @@ mod tests {
         }
     }
 
-    #[allow(clippy::too_many_arguments, clippy::cast_precision_loss)]
+    #[allow(clippy::too_many_arguments)]
     fn make_backtest_result(
         _total_pnl: f64,
         sharpe: f64,

--- a/src/tools/load_data.rs
+++ b/src/tools/load_data.rs
@@ -52,7 +52,6 @@ pub async fn execute(
         let min_scalar = date_col.min_reduce()?;
         let max_scalar = date_col.max_reduce()?;
 
-        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let format_scalar = |s: polars::prelude::Scalar| -> Option<String> {
             match s.value() {
                 AnyValue::Null => None,


### PR DESCRIPTION
Move cast_possible_truncation, cast_sign_loss, cast_possible_wrap, and cast_precision_loss allows from crate-level attributes in main.rs/lib.rs into [lints.clippy] in Cargo.toml for a single source of truth. Remove 13 now-redundant inline #[allow(clippy::cast_*)] annotations across event_sim, exits, metrics, ai_format, and load_data modules.

https://claude.ai/code/session_01U6o9rnjZgv9G8EyWrMXJ5J