### PR TITLE
Rename threshold signals to directional names and add range catalog entries

### DIFF
--- a/src/signals/momentum.rs
+++ b/src/signals/momentum.rs
@@ -10,56 +10,56 @@ const RSI_PERIOD: usize = 14;
 /// Minimum number of data points required to compute MACD (slow EMA + signal line).
 const MACD_MIN_PERIODS: usize = 34;
 
-/// Signal: RSI is below a threshold (oversold condition).
+/// Signal: RSI is below a threshold.
 /// Uses the standard 14-period RSI.
-pub struct RsiOversold {
+pub struct RsiBelow {
     pub column: String,
     pub threshold: f64,
 }
 
-impl SignalFn for RsiOversold {
+impl SignalFn for RsiBelow {
     fn evaluate(&self, df: &DataFrame) -> Result<Series, PolarsError> {
         let prices = column_to_f64(df, &self.column)?;
         let n = prices.len();
         if n <= RSI_PERIOD {
-            return Ok(BooleanChunked::new("rsi_oversold".into(), vec![false; n]).into_series());
+            return Ok(BooleanChunked::new("rsi_below".into(), vec![false; n]).into_series());
         }
         let rsi_values = sti::rsi(&prices);
         Ok(pad_and_compare(
             &rsi_values,
             n,
             |v| v < self.threshold,
-            "rsi_oversold",
+            "rsi_below",
         ))
     }
     fn name(&self) -> &'static str {
-        "rsi_oversold"
+        "rsi_below"
     }
 }
 
-/// Signal: RSI is above a threshold (overbought condition).
-pub struct RsiOverbought {
+/// Signal: RSI is above a threshold.
+pub struct RsiAbove {
     pub column: String,
     pub threshold: f64,
 }
 
-impl SignalFn for RsiOverbought {
+impl SignalFn for RsiAbove {
     fn evaluate(&self, df: &DataFrame) -> Result<Series, PolarsError> {
         let prices = column_to_f64(df, &self.column)?;
         let n = prices.len();
         if n <= RSI_PERIOD {
-            return Ok(BooleanChunked::new("rsi_overbought".into(), vec![false; n]).into_series());
+            return Ok(BooleanChunked::new("rsi_above".into(), vec![false; n]).into_series());
         }
         let rsi_values = sti::rsi(&prices);
         Ok(pad_and_compare(
             &rsi_values,
             n,
             |v| v > self.threshold,
-            "rsi_overbought",
+            "rsi_above",
         ))
     }
     fn name(&self) -> &'static str {
-        "rsi_overbought"
+        "rsi_above"
     }
 }
 
@@ -159,9 +159,9 @@ fn compute_stochastic(close: &[f64], high: &[f64], low: &[f64], period: usize) -
         .collect()
 }
 
-/// Signal: Stochastic oscillator is below threshold (oversold).
+/// Signal: Stochastic oscillator is below threshold.
 /// Uses the standard formula: (close - `lowest_low`) / (`highest_high` - `lowest_low`) * 100.
-pub struct StochasticOversold {
+pub struct StochasticBelow {
     pub close_col: String,
     pub high_col: String,
     pub low_col: String,
@@ -169,7 +169,7 @@ pub struct StochasticOversold {
     pub threshold: f64,
 }
 
-impl SignalFn for StochasticOversold {
+impl SignalFn for StochasticBelow {
     fn evaluate(&self, df: &DataFrame) -> Result<Series, PolarsError> {
         let close = column_to_f64(df, &self.close_col)?;
         let high = column_to_f64(df, &self.high_col)?;
@@ -177,7 +177,7 @@ impl SignalFn for StochasticOversold {
         let n = close.len();
         if self.period == 0 || n < self.period {
             return Ok(
-                BooleanChunked::new("stochastic_oversold".into(), vec![false; n]).into_series(),
+                BooleanChunked::new("stochastic_below".into(), vec![false; n]).into_series(),
             );
         }
         let stoch_values = compute_stochastic(&close, &high, &low, self.period);
@@ -185,17 +185,17 @@ impl SignalFn for StochasticOversold {
             &stoch_values,
             n,
             |v| v < self.threshold,
-            "stochastic_oversold",
+            "stochastic_below",
         ))
     }
     fn name(&self) -> &'static str {
-        "stochastic_oversold"
+        "stochastic_below"
     }
 }
 
-/// Signal: Stochastic oscillator is above threshold (overbought).
+/// Signal: Stochastic oscillator is above threshold.
 /// Uses the standard formula: (close - `lowest_low`) / (`highest_high` - `lowest_low`) * 100.
-pub struct StochasticOverbought {
+pub struct StochasticAbove {
     pub close_col: String,
     pub high_col: String,
     pub low_col: String,
@@ -203,7 +203,7 @@ pub struct StochasticOverbought {
     pub threshold: f64,
 }
 
-impl SignalFn for StochasticOverbought {
+impl SignalFn for StochasticAbove {
     fn evaluate(&self, df: &DataFrame) -> Result<Series, PolarsError> {
         let close = column_to_f64(df, &self.close_col)?;
         let high = column_to_f64(df, &self.high_col)?;
@@ -211,7 +211,7 @@ impl SignalFn for StochasticOverbought {
         let n = close.len();
         if self.period == 0 || n < self.period {
             return Ok(
-                BooleanChunked::new("stochastic_overbought".into(), vec![false; n]).into_series(),
+                BooleanChunked::new("stochastic_above".into(), vec![false; n]).into_series(),
             );
         }
         let stoch_values = compute_stochastic(&close, &high, &low, self.period);
@@ -219,11 +219,11 @@ impl SignalFn for StochasticOverbought {
             &stoch_values,
             n,
             |v| v > self.threshold,
-            "stochastic_overbought",
+            "stochastic_above",
         ))
     }
     fn name(&self) -> &'static str {
-        "stochastic_overbought"
+        "stochastic_above"
     }
 }
 
@@ -242,9 +242,9 @@ mod tests {
     }
 
     #[test]
-    fn rsi_oversold_produces_correct_length() {
+    fn rsi_below_produces_correct_length() {
         let df = sample_df();
-        let signal = RsiOversold {
+        let signal = RsiBelow {
             column: "close".into(),
             threshold: 30.0,
         };
@@ -260,7 +260,7 @@ mod tests {
             "low" => &[99.0, 101.0],
         }
         .unwrap();
-        let signal = StochasticOversold {
+        let signal = StochasticBelow {
             close_col: "close".into(),
             high_col: "high".into(),
             low_col: "low".into(),
@@ -273,9 +273,9 @@ mod tests {
     }
 
     #[test]
-    fn rsi_overbought_produces_correct_length() {
+    fn rsi_above_produces_correct_length() {
         let df = sample_df();
-        let signal = RsiOverbought {
+        let signal = RsiAbove {
             column: "close".into(),
             threshold: 70.0,
         };
@@ -284,9 +284,9 @@ mod tests {
     }
 
     #[test]
-    fn rsi_oversold_insufficient_data() {
+    fn rsi_below_insufficient_data() {
         let df = df! { "close" => &[100.0, 102.0, 101.0] }.unwrap();
-        let signal = RsiOversold {
+        let signal = RsiBelow {
             column: "close".into(),
             threshold: 30.0,
         };
@@ -296,9 +296,9 @@ mod tests {
     }
 
     #[test]
-    fn rsi_overbought_insufficient_data() {
+    fn rsi_above_insufficient_data() {
         let df = df! { "close" => &[100.0, 102.0, 101.0] }.unwrap();
-        let signal = RsiOverbought {
+        let signal = RsiAbove {
             column: "close".into(),
             threshold: 70.0,
         };
@@ -388,7 +388,7 @@ mod tests {
     }
 
     #[test]
-    fn stochastic_overbought_correct_length() {
+    fn stochastic_above_correct_length() {
         let close: Vec<f64> = (0..20).map(|i| 100.0 + f64::from(i)).collect();
         let high: Vec<f64> = close.iter().map(|c| c + 2.0).collect();
         let low: Vec<f64> = close.iter().map(|c| c - 2.0).collect();
@@ -398,7 +398,7 @@ mod tests {
             "low" => &low,
         }
         .unwrap();
-        let signal = StochasticOverbought {
+        let signal = StochasticAbove {
             close_col: "close".into(),
             high_col: "high".into(),
             low_col: "low".into(),
@@ -410,14 +410,14 @@ mod tests {
     }
 
     #[test]
-    fn stochastic_overbought_insufficient_data() {
+    fn stochastic_above_insufficient_data() {
         let df = df! {
             "close" => &[100.0, 102.0],
             "high" => &[103.0, 104.0],
             "low" => &[99.0, 101.0],
         }
         .unwrap();
-        let signal = StochasticOverbought {
+        let signal = StochasticAbove {
             close_col: "close".into(),
             high_col: "high".into(),
             low_col: "low".into(),
@@ -437,7 +437,7 @@ mod tests {
             "low" => &[99.0, 101.0, 100.0],
         }
         .unwrap();
-        let signal = StochasticOversold {
+        let signal = StochasticBelow {
             close_col: "close".into(),
             high_col: "high".into(),
             low_col: "low".into(),
@@ -480,21 +480,21 @@ mod tests {
     }
 
     #[test]
-    fn rsi_oversold_name() {
-        let signal = RsiOversold {
+    fn rsi_below_name() {
+        let signal = RsiBelow {
             column: "close".into(),
             threshold: 30.0,
         };
-        assert_eq!(signal.name(), "rsi_oversold");
+        assert_eq!(signal.name(), "rsi_below");
     }
 
     #[test]
-    fn rsi_overbought_name() {
-        let signal = RsiOverbought {
+    fn rsi_above_name() {
+        let signal = RsiAbove {
             column: "close".into(),
             threshold: 70.0,
         };
-        assert_eq!(signal.name(), "rsi_overbought");
+        assert_eq!(signal.name(), "rsi_above");
     }
 
     #[test]
@@ -522,26 +522,26 @@ mod tests {
     }
 
     #[test]
-    fn stochastic_oversold_name() {
-        let signal = StochasticOversold {
+    fn stochastic_below_name() {
+        let signal = StochasticBelow {
             close_col: "close".into(),
             high_col: "high".into(),
             low_col: "low".into(),
             period: 14,
             threshold: 20.0,
         };
-        assert_eq!(signal.name(), "stochastic_oversold");
+        assert_eq!(signal.name(), "stochastic_below");
     }
 
     #[test]
-    fn stochastic_overbought_name() {
-        let signal = StochasticOverbought {
+    fn stochastic_above_name() {
+        let signal = StochasticAbove {
             close_col: "close".into(),
             high_col: "high".into(),
             low_col: "low".into(),
             period: 14,
             threshold: 80.0,
         };
-        assert_eq!(signal.name(), "stochastic_overbought");
+        assert_eq!(signal.name(), "stochastic_above");
     }
 }

--- a/src/signals/registry.rs
+++ b/src/signals/registry.rs
@@ -5,8 +5,7 @@ use super::combinators::{AndSignal, OrSignal};
 use super::custom::FormulaSignal;
 use super::helpers::SignalFn;
 use super::momentum::{
-    MacdBearish, MacdBullish, MacdCrossover, RsiOverbought, RsiOversold, StochasticOverbought,
-    StochasticOversold,
+    MacdBearish, MacdBullish, MacdCrossover, RsiAbove, RsiBelow, StochasticAbove, StochasticBelow,
 };
 use super::overlap::{
     EmaCrossover, EmaCrossunder, PriceAboveEma, PriceAboveSma, PriceBelowEma, PriceBelowSma,
@@ -20,7 +19,7 @@ use super::volatility::{
     AtrAbove, AtrBelow, BollingerLowerTouch, BollingerUpperTouch, KeltnerLowerBreak,
     KeltnerUpperBreak,
 };
-use super::volume::{CmfNegative, CmfPositive, MfiOverbought, MfiOversold, ObvFalling, ObvRising};
+use super::volume::{CmfNegative, CmfPositive, MfiAbove, MfiBelow, ObvFalling, ObvRising};
 
 /// Serializable signal specification. Each variant maps 1:1 to a `SignalFn` struct.
 /// Use `build_signal` to convert a `SignalSpec` into a concrete `Box<dyn SignalFn>`.
@@ -28,11 +27,11 @@ use super::volume::{CmfNegative, CmfPositive, MfiOverbought, MfiOversold, ObvFal
 #[serde(tag = "type")]
 pub enum SignalSpec {
     // -- Momentum --
-    RsiOversold {
+    RsiBelow {
         column: String,
         threshold: f64,
     },
-    RsiOverbought {
+    RsiAbove {
         column: String,
         threshold: f64,
     },
@@ -45,14 +44,14 @@ pub enum SignalSpec {
     MacdCrossover {
         column: String,
     },
-    StochasticOversold {
+    StochasticBelow {
         close_col: String,
         high_col: String,
         low_col: String,
         period: usize,
         threshold: f64,
     },
-    StochasticOverbought {
+    StochasticAbove {
         close_col: String,
         high_col: String,
         low_col: String,
@@ -198,7 +197,7 @@ pub enum SignalSpec {
     },
 
     // -- Volume --
-    MfiOversold {
+    MfiBelow {
         high_col: String,
         low_col: String,
         close_col: String,
@@ -206,7 +205,7 @@ pub enum SignalSpec {
         period: usize,
         threshold: f64,
     },
-    MfiOverbought {
+    MfiAbove {
         high_col: String,
         low_col: String,
         close_col: String,
@@ -288,11 +287,11 @@ fn build_signal_depth(spec: &SignalSpec, depth: usize) -> Box<dyn SignalFn> {
     }
     match spec {
         // Momentum
-        SignalSpec::RsiOversold { column, threshold } => Box::new(RsiOversold {
+        SignalSpec::RsiBelow { column, threshold } => Box::new(RsiBelow {
             column: column.clone(),
             threshold: *threshold,
         }),
-        SignalSpec::RsiOverbought { column, threshold } => Box::new(RsiOverbought {
+        SignalSpec::RsiAbove { column, threshold } => Box::new(RsiAbove {
             column: column.clone(),
             threshold: *threshold,
         }),
@@ -305,26 +304,26 @@ fn build_signal_depth(spec: &SignalSpec, depth: usize) -> Box<dyn SignalFn> {
         SignalSpec::MacdCrossover { column } => Box::new(MacdCrossover {
             column: column.clone(),
         }),
-        SignalSpec::StochasticOversold {
+        SignalSpec::StochasticBelow {
             close_col,
             high_col,
             low_col,
             period,
             threshold,
-        } => Box::new(StochasticOversold {
+        } => Box::new(StochasticBelow {
             close_col: close_col.clone(),
             high_col: high_col.clone(),
             low_col: low_col.clone(),
             period: *period,
             threshold: *threshold,
         }),
-        SignalSpec::StochasticOverbought {
+        SignalSpec::StochasticAbove {
             close_col,
             high_col,
             low_col,
             period,
             threshold,
-        } => Box::new(StochasticOverbought {
+        } => Box::new(StochasticAbove {
             close_col: close_col.clone(),
             high_col: high_col.clone(),
             low_col: low_col.clone(),
@@ -550,14 +549,14 @@ fn build_signal_depth(spec: &SignalSpec, depth: usize) -> Box<dyn SignalFn> {
         }),
 
         // Volume
-        SignalSpec::MfiOversold {
+        SignalSpec::MfiBelow {
             high_col,
             low_col,
             close_col,
             volume_col,
             period,
             threshold,
-        } => Box::new(MfiOversold {
+        } => Box::new(MfiBelow {
             high_col: high_col.clone(),
             low_col: low_col.clone(),
             close_col: close_col.clone(),
@@ -565,14 +564,14 @@ fn build_signal_depth(spec: &SignalSpec, depth: usize) -> Box<dyn SignalFn> {
             period: *period,
             threshold: *threshold,
         }),
-        SignalSpec::MfiOverbought {
+        SignalSpec::MfiAbove {
             high_col,
             low_col,
             close_col,
             volume_col,
             period,
             threshold,
-        } => Box::new(MfiOverbought {
+        } => Box::new(MfiAbove {
             high_col: high_col.clone(),
             low_col: low_col.clone(),
             close_col: close_col.clone(),
@@ -672,15 +671,15 @@ pub struct SignalInfo {
 pub const SIGNAL_CATALOG: &[SignalInfo] = &[
     // Momentum
     SignalInfo {
-        name: "RsiOversold",
+        name: "RsiBelow",
         category: "momentum",
-        description: "RSI below threshold (oversold). Uses 14-period RSI.",
+        description: "RSI below threshold. Uses 14-period RSI.",
         params: "column, threshold (e.g. 30.0)",
     },
     SignalInfo {
-        name: "RsiOverbought",
+        name: "RsiAbove",
         category: "momentum",
-        description: "RSI above threshold (overbought). Uses 14-period RSI.",
+        description: "RSI above threshold. Uses 14-period RSI.",
         params: "column, threshold (e.g. 70.0)",
     },
     SignalInfo {
@@ -702,15 +701,15 @@ pub const SIGNAL_CATALOG: &[SignalInfo] = &[
         params: "column",
     },
     SignalInfo {
-        name: "StochasticOversold",
+        name: "StochasticBelow",
         category: "momentum",
-        description: "Stochastic oscillator below threshold.",
+        description: "Stochastic oscillator below threshold. Uses rolling %K.",
         params: "close_col, high_col, low_col, period, threshold",
     },
     SignalInfo {
-        name: "StochasticOverbought",
+        name: "StochasticAbove",
         category: "momentum",
-        description: "Stochastic oscillator above threshold.",
+        description: "Stochastic oscillator above threshold. Uses rolling %K.",
         params: "close_col, high_col, low_col, period, threshold",
     },
     // Overlap
@@ -869,15 +868,15 @@ pub const SIGNAL_CATALOG: &[SignalInfo] = &[
     },
     // Volume
     SignalInfo {
-        name: "MfiOversold",
+        name: "MfiBelow",
         category: "volume",
-        description: "Money Flow Index below threshold (oversold by volume-weighted momentum).",
+        description: "Money Flow Index below threshold.",
         params: "high_col, low_col, close_col, volume_col, period, threshold",
     },
     SignalInfo {
-        name: "MfiOverbought",
+        name: "MfiAbove",
         category: "volume",
-        description: "Money Flow Index above threshold (overbought).",
+        description: "Money Flow Index above threshold.",
         params: "high_col, low_col, close_col, volume_col, period, threshold",
     },
     SignalInfo {
@@ -904,6 +903,34 @@ pub const SIGNAL_CATALOG: &[SignalInfo] = &[
         description: "Chaikin Money Flow < 0 (selling pressure).",
         params: "close_col, high_col, low_col, volume_col, period",
     },
+    // Range (synthetic catalog entries for And combinator patterns)
+    SignalInfo {
+        name: "RsiRange",
+        category: "momentum",
+        description:
+            "RSI within a range (e.g. 30-40). Uses And combinator with RsiAbove + RsiBelow.",
+        params: "And { RsiAbove { threshold: lower }, RsiBelow { threshold: upper } }",
+    },
+    SignalInfo {
+        name: "StochasticRange",
+        category: "momentum",
+        description:
+            "Stochastic within a range. Uses And combinator with StochasticAbove + StochasticBelow.",
+        params:
+            "And { StochasticAbove { threshold: lower }, StochasticBelow { threshold: upper } }",
+    },
+    SignalInfo {
+        name: "AtrRange",
+        category: "volatility",
+        description: "ATR within a range. Uses And combinator with AtrAbove + AtrBelow.",
+        params: "And { AtrAbove { threshold: lower }, AtrBelow { threshold: upper } }",
+    },
+    SignalInfo {
+        name: "MfiRange",
+        category: "volume",
+        description: "MFI within a range. Uses And combinator with MfiAbove + MfiBelow.",
+        params: "And { MfiAbove { threshold: lower }, MfiBelow { threshold: upper } }",
+    },
 ];
 
 #[cfg(test)]
@@ -912,18 +939,18 @@ mod tests {
 
     #[test]
     fn build_signal_round_trip_rsi() {
-        let spec = SignalSpec::RsiOversold {
+        let spec = SignalSpec::RsiBelow {
             column: "close".into(),
             threshold: 30.0,
         };
         let signal = build_signal(&spec);
-        assert_eq!(signal.name(), "rsi_oversold");
+        assert_eq!(signal.name(), "rsi_below");
     }
 
     #[test]
     fn build_signal_and_combinator() {
         let spec = SignalSpec::And {
-            left: Box::new(SignalSpec::RsiOversold {
+            left: Box::new(SignalSpec::RsiBelow {
                 column: "close".into(),
                 threshold: 30.0,
             }),
@@ -937,34 +964,34 @@ mod tests {
 
     #[test]
     fn signal_spec_serde_round_trip() {
-        let spec = SignalSpec::RsiOversold {
+        let spec = SignalSpec::RsiBelow {
             column: "close".into(),
             threshold: 30.0,
         };
         let json = serde_json::to_string(&spec).unwrap();
         let parsed: SignalSpec = serde_json::from_str(&json).unwrap();
-        if let SignalSpec::RsiOversold { column, threshold } = parsed {
+        if let SignalSpec::RsiBelow { column, threshold } = parsed {
             assert_eq!(column, "close");
             assert_eq!(threshold, 30.0);
         } else {
-            panic!("expected RsiOversold");
+            panic!("expected RsiBelow");
         }
     }
 
     #[test]
     fn catalog_has_all_signals() {
-        // 38 signals (excluding And/Or combinators)
-        assert_eq!(SIGNAL_CATALOG.len(), 38);
+        // 42 signals (excluding And/Or combinators; includes 4 range entries)
+        assert_eq!(SIGNAL_CATALOG.len(), 42);
     }
 
     #[test]
     fn build_signal_round_trip_rsi_overbought() {
-        let spec = SignalSpec::RsiOverbought {
+        let spec = SignalSpec::RsiAbove {
             column: "close".into(),
             threshold: 70.0,
         };
         let signal = build_signal(&spec);
-        assert_eq!(signal.name(), "rsi_overbought");
+        assert_eq!(signal.name(), "rsi_above");
     }
 
     #[test]
@@ -993,26 +1020,26 @@ mod tests {
 
     #[test]
     fn build_signal_stochastic_oversold() {
-        let signal = build_signal(&SignalSpec::StochasticOversold {
+        let signal = build_signal(&SignalSpec::StochasticBelow {
             close_col: "close".into(),
             high_col: "high".into(),
             low_col: "low".into(),
             period: 14,
             threshold: 20.0,
         });
-        assert_eq!(signal.name(), "stochastic_oversold");
+        assert_eq!(signal.name(), "stochastic_below");
     }
 
     #[test]
     fn build_signal_stochastic_overbought() {
-        let signal = build_signal(&SignalSpec::StochasticOverbought {
+        let signal = build_signal(&SignalSpec::StochasticAbove {
             close_col: "close".into(),
             high_col: "high".into(),
             low_col: "low".into(),
             period: 14,
             threshold: 80.0,
         });
-        assert_eq!(signal.name(), "stochastic_overbought");
+        assert_eq!(signal.name(), "stochastic_above");
     }
 
     #[test]
@@ -1271,7 +1298,7 @@ mod tests {
 
     #[test]
     fn build_signal_mfi_oversold() {
-        let signal = build_signal(&SignalSpec::MfiOversold {
+        let signal = build_signal(&SignalSpec::MfiBelow {
             high_col: "high".into(),
             low_col: "low".into(),
             close_col: "close".into(),
@@ -1279,12 +1306,12 @@ mod tests {
             period: 14,
             threshold: 20.0,
         });
-        assert_eq!(signal.name(), "mfi_oversold");
+        assert_eq!(signal.name(), "mfi_below");
     }
 
     #[test]
     fn build_signal_mfi_overbought() {
-        let signal = build_signal(&SignalSpec::MfiOverbought {
+        let signal = build_signal(&SignalSpec::MfiAbove {
             high_col: "high".into(),
             low_col: "low".into(),
             close_col: "close".into(),
@@ -1292,7 +1319,7 @@ mod tests {
             period: 14,
             threshold: 80.0,
         });
-        assert_eq!(signal.name(), "mfi_overbought");
+        assert_eq!(signal.name(), "mfi_above");
     }
 
     #[test]
@@ -1340,7 +1367,7 @@ mod tests {
     #[test]
     fn build_signal_or_combinator() {
         let spec = SignalSpec::Or {
-            left: Box::new(SignalSpec::RsiOversold {
+            left: Box::new(SignalSpec::RsiBelow {
                 column: "close".into(),
                 threshold: 30.0,
             }),
@@ -1369,7 +1396,7 @@ mod tests {
     #[test]
     fn signal_spec_serde_round_trip_and_combinator() {
         let spec = SignalSpec::And {
-            left: Box::new(SignalSpec::RsiOversold {
+            left: Box::new(SignalSpec::RsiBelow {
                 column: "close".into(),
                 threshold: 30.0,
             }),
@@ -1381,7 +1408,7 @@ mod tests {
         let json = serde_json::to_string(&spec).unwrap();
         let parsed: SignalSpec = serde_json::from_str(&json).unwrap();
         if let SignalSpec::And { left, right } = parsed {
-            assert!(matches!(*left, SignalSpec::RsiOversold { .. }));
+            assert!(matches!(*left, SignalSpec::RsiBelow { .. }));
             assert!(matches!(*right, SignalSpec::PriceAboveSma { .. }));
         } else {
             panic!("expected And");
@@ -1425,7 +1452,7 @@ mod tests {
 
     #[test]
     fn signal_spec_serde_round_trip_stochastic() {
-        let spec = SignalSpec::StochasticOversold {
+        let spec = SignalSpec::StochasticBelow {
             close_col: "close".into(),
             high_col: "high".into(),
             low_col: "low".into(),
@@ -1434,7 +1461,7 @@ mod tests {
         };
         let json = serde_json::to_string(&spec).unwrap();
         let parsed: SignalSpec = serde_json::from_str(&json).unwrap();
-        if let SignalSpec::StochasticOversold {
+        if let SignalSpec::StochasticBelow {
             close_col,
             high_col,
             low_col,
@@ -1448,7 +1475,7 @@ mod tests {
             assert_eq!(period, 14);
             assert_eq!(threshold, 20.0);
         } else {
-            panic!("expected StochasticOversold");
+            panic!("expected StochasticBelow");
         }
     }
 

--- a/src/signals/volume.rs
+++ b/src/signals/volume.rs
@@ -12,9 +12,9 @@ fn compute_typical_price(high: &[f64], low: &[f64], close: &[f64]) -> Vec<f64> {
         .collect()
 }
 
-/// Signal: Money Flow Index is below a threshold (oversold by volume-weighted momentum).
+/// Signal: Money Flow Index is below a threshold.
 /// Typical price is computed internally as `(high + low + close) / 3`.
-pub struct MfiOversold {
+pub struct MfiBelow {
     pub high_col: String,
     pub low_col: String,
     pub close_col: String,
@@ -23,7 +23,7 @@ pub struct MfiOversold {
     pub threshold: f64,
 }
 
-impl SignalFn for MfiOversold {
+impl SignalFn for MfiBelow {
     fn evaluate(&self, df: &DataFrame) -> Result<Series, PolarsError> {
         let high = column_to_f64(df, &self.high_col)?;
         let low = column_to_f64(df, &self.low_col)?;
@@ -32,7 +32,7 @@ impl SignalFn for MfiOversold {
         let typical = compute_typical_price(&high, &low, &close);
         let n = typical.len();
         if n < self.period {
-            return Ok(BooleanChunked::new("mfi_oversold".into(), vec![false; n]).into_series());
+            return Ok(BooleanChunked::new("mfi_below".into(), vec![false; n]).into_series());
         }
         let mfi_values =
             rust_ti::momentum_indicators::bulk::money_flow_index(&typical, &volume, self.period);
@@ -40,17 +40,17 @@ impl SignalFn for MfiOversold {
             &mfi_values,
             n,
             |v| v < self.threshold,
-            "mfi_oversold",
+            "mfi_below",
         ))
     }
     fn name(&self) -> &'static str {
-        "mfi_oversold"
+        "mfi_below"
     }
 }
 
-/// Signal: Money Flow Index is above a threshold (overbought).
+/// Signal: Money Flow Index is above a threshold.
 /// Typical price is computed internally as `(high + low + close) / 3`.
-pub struct MfiOverbought {
+pub struct MfiAbove {
     pub high_col: String,
     pub low_col: String,
     pub close_col: String,
@@ -59,7 +59,7 @@ pub struct MfiOverbought {
     pub threshold: f64,
 }
 
-impl SignalFn for MfiOverbought {
+impl SignalFn for MfiAbove {
     fn evaluate(&self, df: &DataFrame) -> Result<Series, PolarsError> {
         let high = column_to_f64(df, &self.high_col)?;
         let low = column_to_f64(df, &self.low_col)?;
@@ -68,7 +68,7 @@ impl SignalFn for MfiOverbought {
         let typical = compute_typical_price(&high, &low, &close);
         let n = typical.len();
         if n < self.period {
-            return Ok(BooleanChunked::new("mfi_overbought".into(), vec![false; n]).into_series());
+            return Ok(BooleanChunked::new("mfi_above".into(), vec![false; n]).into_series());
         }
         let mfi_values =
             rust_ti::momentum_indicators::bulk::money_flow_index(&typical, &volume, self.period);
@@ -76,11 +76,11 @@ impl SignalFn for MfiOverbought {
             &mfi_values,
             n,
             |v| v > self.threshold,
-            "mfi_overbought",
+            "mfi_above",
         ))
     }
     fn name(&self) -> &'static str {
-        "mfi_overbought"
+        "mfi_above"
     }
 }
 
@@ -347,9 +347,9 @@ mod tests {
     }
 
     #[test]
-    fn mfi_oversold_correct_length() {
+    fn mfi_below_correct_length() {
         let df = ohlcv_df();
-        let signal = MfiOversold {
+        let signal = MfiBelow {
             high_col: "high".into(),
             low_col: "low".into(),
             close_col: "close".into(),
@@ -362,9 +362,9 @@ mod tests {
     }
 
     #[test]
-    fn mfi_overbought_correct_length() {
+    fn mfi_above_correct_length() {
         let df = ohlcv_df();
-        let signal = MfiOverbought {
+        let signal = MfiAbove {
             high_col: "high".into(),
             low_col: "low".into(),
             close_col: "close".into(),
@@ -377,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    fn mfi_oversold_insufficient_data() {
+    fn mfi_below_insufficient_data() {
         let df = df! {
             "close" => &[100.0, 101.0],
             "high" => &[102.0, 103.0],
@@ -385,7 +385,7 @@ mod tests {
             "volume" => &[1000.0, 1100.0],
         }
         .unwrap();
-        let signal = MfiOversold {
+        let signal = MfiBelow {
             high_col: "high".into(),
             low_col: "low".into(),
             close_col: "close".into(),
@@ -399,7 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn mfi_overbought_insufficient_data() {
+    fn mfi_above_insufficient_data() {
         let df = df! {
             "close" => &[100.0, 101.0],
             "high" => &[102.0, 103.0],
@@ -407,7 +407,7 @@ mod tests {
             "volume" => &[1000.0, 1100.0],
         }
         .unwrap();
-        let signal = MfiOverbought {
+        let signal = MfiAbove {
             high_col: "high".into(),
             low_col: "low".into(),
             close_col: "close".into(),
@@ -520,8 +520,8 @@ mod tests {
     }
 
     #[test]
-    fn mfi_oversold_name() {
-        let signal = MfiOversold {
+    fn mfi_below_name() {
+        let signal = MfiBelow {
             high_col: "high".into(),
             low_col: "low".into(),
             close_col: "close".into(),
@@ -529,12 +529,12 @@ mod tests {
             period: 14,
             threshold: 20.0,
         };
-        assert_eq!(signal.name(), "mfi_oversold");
+        assert_eq!(signal.name(), "mfi_below");
     }
 
     #[test]
-    fn mfi_overbought_name() {
-        let signal = MfiOverbought {
+    fn mfi_above_name() {
+        let signal = MfiAbove {
             high_col: "high".into(),
             low_col: "low".into(),
             close_col: "close".into(),
@@ -542,7 +542,7 @@ mod tests {
             period: 14,
             threshold: 80.0,
         };
-        assert_eq!(signal.name(), "mfi_overbought");
+        assert_eq!(signal.name(), "mfi_above");
     }
 
     #[test]

--- a/src/tools/construct_signal.rs
+++ b/src/tools/construct_signal.rs
@@ -62,10 +62,14 @@ pub fn execute(prompt: &str) -> ConstructSignalResponse {
         )
     };
 
-    let suggested_next_steps = vec![
+    let has_range_candidates = candidates.iter().any(|c| c.name.ends_with("Range"));
+    let mut suggested_next_steps = vec![
         "Pick a candidate from above or use the schema to construct a custom SignalSpec".to_string(),
         "Pass the JSON example as entry_signal or exit_signal in run_backtest — OHLCV data is auto-fetched when signals are used".to_string(),
     ];
+    if has_range_candidates {
+        suggested_next_steps.push("Range signals use the And combinator pattern. Adjust the min/max thresholds in the example to define your range.".to_string());
+    }
 
     ConstructSignalResponse {
         summary,
@@ -78,7 +82,7 @@ pub fn execute(prompt: &str) -> ConstructSignalResponse {
 }
 
 /// Split a CamelCase string into lowercase words.
-/// E.g., `RsiOversold` → `["rsi", "oversold"]`
+/// E.g., `RsiBelow` → `["rsi", "oversold"]`
 fn split_camel_case(s: &str) -> Vec<String> {
     let mut words = Vec::new();
     let mut current = String::new();
@@ -182,13 +186,13 @@ fn fuzzy_search(prompt: &str) -> (Vec<SignalCandidate>, bool) {
 fn build_example(signal_name: &str) -> Value {
     match signal_name {
         // Momentum
-        "RsiOversold" => json!({
-            "type": "RsiOversold",
+        "RsiBelow" => json!({
+            "type": "RsiBelow",
             "column": DEFAULT_CLOSE,
             "threshold": 30.0,
         }),
-        "RsiOverbought" => json!({
-            "type": "RsiOverbought",
+        "RsiAbove" => json!({
+            "type": "RsiAbove",
             "column": DEFAULT_CLOSE,
             "threshold": 70.0,
         }),
@@ -204,16 +208,16 @@ fn build_example(signal_name: &str) -> Value {
             "type": "MacdCrossover",
             "column": DEFAULT_CLOSE,
         }),
-        "StochasticOversold" => json!({
-            "type": "StochasticOversold",
+        "StochasticBelow" => json!({
+            "type": "StochasticBelow",
             "close_col": DEFAULT_CLOSE,
             "high_col": DEFAULT_HIGH,
             "low_col": DEFAULT_LOW,
             "period": 14,
             "threshold": 20.0,
         }),
-        "StochasticOverbought" => json!({
-            "type": "StochasticOverbought",
+        "StochasticAbove" => json!({
+            "type": "StochasticAbove",
             "close_col": DEFAULT_CLOSE,
             "high_col": DEFAULT_HIGH,
             "low_col": DEFAULT_LOW,
@@ -379,8 +383,8 @@ fn build_example(signal_name: &str) -> Value {
             "threshold": 0.02,
         }),
         // Volume
-        "MfiOversold" => json!({
-            "type": "MfiOversold",
+        "MfiBelow" => json!({
+            "type": "MfiBelow",
             "high_col": DEFAULT_HIGH,
             "low_col": DEFAULT_LOW,
             "close_col": DEFAULT_CLOSE,
@@ -388,8 +392,8 @@ fn build_example(signal_name: &str) -> Value {
             "period": 14,
             "threshold": 20.0,
         }),
-        "MfiOverbought" => json!({
-            "type": "MfiOverbought",
+        "MfiAbove" => json!({
+            "type": "MfiAbove",
             "high_col": DEFAULT_HIGH,
             "low_col": DEFAULT_LOW,
             "close_col": DEFAULT_CLOSE,
@@ -423,6 +427,27 @@ fn build_example(signal_name: &str) -> Value {
             "volume_col": DEFAULT_VOLUME,
             "period": 20,
         }),
+        // Range (And combinator patterns)
+        "RsiRange" => json!({
+            "type": "And",
+            "left": { "type": "RsiAbove", "column": DEFAULT_CLOSE, "threshold": 30.0 },
+            "right": { "type": "RsiBelow", "column": DEFAULT_CLOSE, "threshold": 40.0 },
+        }),
+        "StochasticRange" => json!({
+            "type": "And",
+            "left": { "type": "StochasticAbove", "close_col": DEFAULT_CLOSE, "high_col": DEFAULT_HIGH, "low_col": DEFAULT_LOW, "period": 14, "threshold": 20.0 },
+            "right": { "type": "StochasticBelow", "close_col": DEFAULT_CLOSE, "high_col": DEFAULT_HIGH, "low_col": DEFAULT_LOW, "period": 14, "threshold": 80.0 },
+        }),
+        "AtrRange" => json!({
+            "type": "And",
+            "left": { "type": "AtrAbove", "close_col": DEFAULT_CLOSE, "high_col": DEFAULT_HIGH, "low_col": DEFAULT_LOW, "period": 14, "threshold": 0.5 },
+            "right": { "type": "AtrBelow", "close_col": DEFAULT_CLOSE, "high_col": DEFAULT_HIGH, "low_col": DEFAULT_LOW, "period": 14, "threshold": 1.5 },
+        }),
+        "MfiRange" => json!({
+            "type": "And",
+            "left": { "type": "MfiAbove", "high_col": DEFAULT_HIGH, "low_col": DEFAULT_LOW, "close_col": DEFAULT_CLOSE, "volume_col": DEFAULT_VOLUME, "period": 14, "threshold": 20.0 },
+            "right": { "type": "MfiBelow", "high_col": DEFAULT_HIGH, "low_col": DEFAULT_LOW, "close_col": DEFAULT_CLOSE, "volume_col": DEFAULT_VOLUME, "period": 14, "threshold": 80.0 },
+        }),
         // Fallback: return a structured placeholder with explicit error message
         _ => json!({
             "type": "UnknownSignal",
@@ -436,11 +461,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fuzzy_search_rsi_oversold() {
-        let (result, had_matches) = fuzzy_search("rsi oversold");
+    fn fuzzy_search_rsi_below() {
+        let (result, had_matches) = fuzzy_search("rsi below");
         let names: Vec<&str> = result.iter().map(|c| c.name.as_str()).collect();
         assert!(had_matches);
-        assert!(names.contains(&"RsiOversold"));
+        assert!(names.contains(&"RsiBelow"));
     }
 
     #[test]
@@ -481,7 +506,7 @@ mod tests {
 
     #[test]
     fn execute_basic() {
-        let response = execute("RSI oversold");
+        let response = execute("RSI below");
         assert!(!response.candidates.is_empty());
         assert!(response.schema != serde_json::Value::Null);
         assert_eq!(response.column_defaults["close"], "adjclose");
@@ -489,8 +514,49 @@ mod tests {
 
     #[test]
     fn build_example_rsi() {
-        let example = build_example("RsiOversold");
-        assert_eq!(example["type"], "RsiOversold");
+        let example = build_example("RsiBelow");
+        assert_eq!(example["type"], "RsiBelow");
         assert_eq!(example["threshold"], 30.0);
+    }
+
+    #[test]
+    fn fuzzy_search_rsi_range() {
+        let (result, had_matches) = fuzzy_search("rsi range");
+        let names: Vec<&str> = result.iter().map(|c| c.name.as_str()).collect();
+        assert!(had_matches);
+        assert!(names.contains(&"RsiRange"));
+    }
+
+    #[test]
+    fn build_example_rsi_range() {
+        let example = build_example("RsiRange");
+        assert_eq!(example["type"], "And");
+        assert_eq!(example["left"]["type"], "RsiAbove");
+        assert_eq!(example["left"]["threshold"], 30.0);
+        assert_eq!(example["right"]["type"], "RsiBelow");
+        assert_eq!(example["right"]["threshold"], 40.0);
+    }
+
+    #[test]
+    fn rsi_range_roundtrip_deserialize() {
+        let example = build_example("RsiRange");
+        let spec: SignalSpec = serde_json::from_value(example).unwrap();
+        if let SignalSpec::And { left, right } = spec {
+            assert!(matches!(*left, SignalSpec::RsiAbove { .. }));
+            assert!(matches!(*right, SignalSpec::RsiBelow { .. }));
+        } else {
+            panic!("expected And combinator");
+        }
+    }
+
+    #[test]
+    fn execute_rsi_range_shows_range_hint() {
+        let response = execute("RSI range");
+        let has_range = response.candidates.iter().any(|c| c.name == "RsiRange");
+        assert!(has_range);
+        assert!(response
+            .suggested_next_steps
+            .iter()
+            .any(|s| s.contains("Range signals use the And combinator")));
     }
 }


### PR DESCRIPTION
## Summary

Closes #57.

- **Rename 6 signal variants** from overbought/oversold to directional above/below names: `RsiBelow`, `RsiAbove`, `StochasticBelow`, `StochasticAbove`, `MfiBelow`, `MfiAbove` (breaking schema change)
- **Add 4 synthetic range catalog entries** (`RsiRange`, `StochasticRange`, `AtrRange`, `MfiRange`) that surface the `And` combinator pattern via `construct_signal` fuzzy search
- Add conditional hint in `suggested_next_steps` when range candidates are present

## Test plan

- [x] `cargo test` — all 527 tests pass (including 4 new tests)
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] New tests: `fuzzy_search_rsi_range`, `build_example_rsi_range`, `rsi_range_roundtrip_deserialize`, `execute_rsi_range_shows_range_hint`
- [x] Catalog count updated 38 → 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)